### PR TITLE
Ensure grunt-exec is loaded

### DIFF
--- a/tasks/pkgbuild.js
+++ b/tasks/pkgbuild.js
@@ -112,7 +112,7 @@ module.exports = function(grunt) {
   });
     
     
-    var libs = ['grunt-plistbuddy'];
+    var libs = ['grunt-plistbuddy', 'grunt-exec'];
     
     var apppath = process.cwd(),
     dirfiles = [],


### PR DESCRIPTION
If a Gruntfile did not load `grunt-exec` itself, `grunt-pkgbuild` would exit on the mkdir step
